### PR TITLE
Add private key scanner plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,11 @@ Find x.509 certificates
 Verify the executability of cryptographic assets from Java code
 Adds a confidence level (0-100) to the CBOM components to show how likely it is that this component is actually executable
 
-> "secrets": Secret Plugin
+> "secrets": Secret Detection Plugin
 Find Secrets & Keys
+
+> "keys": Private Keys Scanner
+Scans for private keys in the filesystem and adds them to the BOM
 
 Usage:
   cbomkit-theia [command]
@@ -70,7 +73,7 @@ Flags:
   -b, --bom string        BOM file to be verified and enriched
       --config string     config file (default is $HOME/.cbomkit-theia.yaml)
   -h, --help              help for cbomkit-theia
-  -p, --plugins strings   list of plugins to use (default [certificates,javasecurity,secrets])
+  -p, --plugins strings   list of plugins to use (default [certificates,javasecurity,secrets,keys])
       --schema string     BOM schema to validate the given BOM (default "provider/cyclonedx/bom-1.6.schema.json")
 
 Use "cbomkit-theia [command] --help" for more information about a command.
@@ -101,6 +104,25 @@ go build
 ./cbomkit-theia [command] > enriched_CBOM.json
 ```
 
+## Configuration
+
+CBOMkit-theia reads its configuration from `$HOME/.cbomkit-theia/config.yaml`. This file is automatically created on first run.
+
+### Plugins
+
+By default, all available plugins are enabled:
+- certificates
+- javasecurity
+- secrets
+- keys
+
+**Important Note:** The application is configured to ensure all plugins are always available. If you manually edit the configuration file to exclude specific plugins, CBOMkit-theia will detect this and automatically restore all plugins to their default enabled state on the next run. If you need to disable specific plugins for a particular run, use the `-p` flag instead of modifying the config file:
+
+```shell
+# Run with only specific plugins
+./cbomkit-theia image nginx -p certificates -p secrets
+```
+
 ## Development
 
 ### Plugins
@@ -115,6 +137,9 @@ go build
   - Secret Plugin:
     - Leverages [gitleaks](https://github.com/gitleaks/gitleaks) to find secrets and keys in the data source
     - Adds the secrets and keys to the CBOM
+  - Private Keys Scanner:
+    - Scans for private keys in the filesystem
+    - Adds the detected private keys to the CBOM
 
 Additional plugins can be added by implementing the `Plugin` interface from [`ibm/cbomkit-theia/scanner/plugins`](./scanner/plugins/plugin.go#L41) and adding the plugins constructor to the `GetAllPluginConstructors` function in [`ibm/cbomkit-theia/scanner/scanner.go`](./scanner/scanner.go#L58): 
 

--- a/scanner/plugins/keys/keys.go
+++ b/scanner/plugins/keys/keys.go
@@ -1,0 +1,188 @@
+// Copyright 2024 IBM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package keys
+
+import (
+	"encoding/pem"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/IBM/cbomkit-theia/provider/filesystem"
+	pemlib "github.com/IBM/cbomkit-theia/scanner/pem"
+	pluginpackage "github.com/IBM/cbomkit-theia/scanner/plugins"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+// KeysPlugin implements the Plugin interface
+type KeysPlugin struct{}
+
+// NewKeysPlugin returns a new instance of the KeysPlugin
+func NewKeysPlugin() (pluginpackage.Plugin, error) {
+	return &KeysPlugin{}, nil
+}
+
+// GetName returns the name of the plugin
+func (p *KeysPlugin) GetName() string {
+	return "Private Keys Scanner"
+}
+
+// GetExplanation returns an explanation of what the plugin does
+func (p *KeysPlugin) GetExplanation() string {
+	return "Scans for private keys in the filesystem and adds them to the BOM"
+}
+
+// GetType returns the type of the plugin
+func (p *KeysPlugin) GetType() pluginpackage.PluginType {
+	return pluginpackage.PluginTypeAppend
+}
+
+// Private key extensions to search for
+var privateKeyExtensions = []string{
+	".pem", ".key", ".pkcs8", ".p8", ".pkcs12", ".p12", ".pfx", ".keystore", ".jks",
+}
+
+// UpdateBOM implements the Plugin interface
+func (p *KeysPlugin) UpdateBOM(fs filesystem.Filesystem, bom *cdx.BOM) error {
+	log.Info("Looking for private keys...")
+
+	var files []string
+
+	// Walk the filesystem looking for files with potential private key extensions
+	err := fs.WalkDir(func(path string) error {
+		ext := strings.ToLower(filepath.Ext(path))
+		for _, keyExt := range privateKeyExtensions {
+			if ext == keyExt {
+				files = append(files, path)
+				break
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to walk filesystem: %w", err)
+	}
+
+	// Process each file that might contain private keys
+	for _, filePath := range files {
+		// Skip large files
+		maxFileSize := viper.GetInt64("keys.max_file_size")
+		if maxFileSize <= 0 {
+			maxFileSize = 1024 * 1024 // Default to 1MB
+		}
+
+		// Open and read the file
+		reader, err := fs.Open(filePath)
+		if err != nil {
+			log.WithError(err).Warnf("Failed to open file %s", filePath)
+			continue
+		}
+		
+		data, err := filesystem.ReadAllAndClose(reader)
+		if err != nil {
+			log.WithError(err).Warnf("Failed to read file %s", filePath)
+			continue
+		}
+
+		// Skip large files
+		if int64(len(data)) > maxFileSize {
+			log.Warnf("Skipping large file: %s (size: %d bytes)", filePath, len(data))
+			continue
+		}
+
+		// Filter for private keys only
+		privateKeyFilter := pemlib.Filter{
+			FilterType: pemlib.PEMTypeFilterTypeAllowlist,
+			List: []pemlib.PEMBlockType{
+				pemlib.PEMBlockTypePrivateKey,
+				pemlib.PEMBlockTypeEncryptedPrivateKey,
+				pemlib.PEMBlockTypeRSAPrivateKey,
+				pemlib.PEMBlockTypeECPrivateKey,
+				pemlib.PEMBlockTypeOPENSSHPrivateKey,
+			},
+		}
+
+		// Parse PEM blocks
+		blocks := pemlib.ParsePEMToBlocksWithTypeFilter(data, privateKeyFilter)
+		if len(blocks) == 0 {
+			continue
+		}
+
+		log.Infof("Found %d private key(s) in %s", len(blocks), filePath)
+
+		// Add each key to the BOM
+		for block, blockType := range blocks {
+			components, err := processPrivateKeyBlock(block, blockType, filePath)
+			if err != nil {
+				log.WithError(err).Warnf("Failed to process private key in %s", filePath)
+				continue
+			}
+
+			// Add the components to the BOM
+			*bom.Components = append(*bom.Components, components...)
+		}
+	}
+
+	return nil
+}
+
+// Process a private key block and return components
+func processPrivateKeyBlock(block *pem.Block, blockType pemlib.PEMBlockType, filePath string) ([]cdx.Component, error) {
+	components, err := pemlib.GenerateComponentsFromPEMKeyBlock(block)
+	if err != nil {
+		return nil, err
+	}
+
+	// Enhance components with additional metadata
+	for i := range components {
+		if components[i].CryptoProperties != nil &&
+			components[i].CryptoProperties.RelatedCryptoMaterialProperties != nil &&
+			components[i].CryptoProperties.RelatedCryptoMaterialProperties.Type == cdx.RelatedCryptoMaterialTypePrivateKey {
+			
+			// Add file path as external reference
+			if components[i].ExternalReferences == nil {
+				components[i].ExternalReferences = &[]cdx.ExternalReference{}
+			}
+			*components[i].ExternalReferences = append(*components[i].ExternalReferences, cdx.ExternalReference{
+				Type:    "other",
+				URL:     fmt.Sprintf("file://%s", filePath),
+				Comment: "File containing the private key",
+			})
+
+			// Add confidence level as property
+			if components[i].Properties == nil {
+				components[i].Properties = &[]cdx.Property{}
+			}
+			*components[i].Properties = append(*components[i].Properties, cdx.Property{
+				Name:  "confidence.level",
+				Value: "1.0", // High confidence
+			})
+
+			// Add warning property
+			*components[i].Properties = append(*components[i].Properties, cdx.Property{
+				Name:  "security.warning",
+				Value: "Private key detected - Handle with care",
+			})
+		}
+	}
+
+	return components, nil
+}

--- a/scanner/plugins/keys/keys_test.go
+++ b/scanner/plugins/keys/keys_test.go
@@ -1,0 +1,42 @@
+// Copyright 2024 IBM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package keys
+
+import (
+	"testing"
+
+	pluginpackage "github.com/IBM/cbomkit-theia/scanner/plugins"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeysPlugin_GetName(t *testing.T) {
+	plugin, err := NewKeysPlugin()
+	assert.NoError(t, err)
+	assert.Equal(t, "Private Keys Scanner", plugin.GetName())
+}
+
+func TestKeysPlugin_GetExplanation(t *testing.T) {
+	plugin, err := NewKeysPlugin()
+	assert.NoError(t, err)
+	assert.Equal(t, "Scans for private keys in the filesystem and adds them to the BOM", plugin.GetExplanation())
+}
+
+func TestKeysPlugin_GetType(t *testing.T) {
+	plugin, err := NewKeysPlugin()
+	assert.NoError(t, err)
+	assert.Equal(t, pluginpackage.PluginTypeAppend, plugin.GetType())
+}

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -30,6 +30,7 @@ import (
 	pluginpackage "github.com/IBM/cbomkit-theia/scanner/plugins"
 	"github.com/IBM/cbomkit-theia/scanner/plugins/certificates"
 	"github.com/IBM/cbomkit-theia/scanner/plugins/javasecurity"
+	"github.com/IBM/cbomkit-theia/scanner/plugins/keys"
 	"github.com/IBM/cbomkit-theia/scanner/plugins/secrets"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
@@ -58,6 +59,7 @@ func GetAllPluginConstructors() map[string]pluginpackage.PluginConstructor {
 		"certificates": certificates.NewCertificatePlugin,
 		"javasecurity": javasecurity.NewJavaSecurityPlugin,
 		"secrets":      secrets.NewSecretsPlugin,
+		"keys":         keys.NewKeysPlugin,
 	}
 }
 


### PR DESCRIPTION
This commit adds a new plugin for detecting private keys in container images and directories. The plugin scans for common private key file extensions and detects private keys using the PEM parser. Private keys are then added to the CBOM with proper metadata including security warnings.