### PR TITLE
Skip certificates if file does not exist at path

### DIFF
--- a/scanner/plugins/certificates/certificates.go
+++ b/scanner/plugins/certificates/certificates.go
@@ -72,6 +72,14 @@ func (certificatesPlugin *Plugin) UpdateBOM(fs filesystem.Filesystem, bom *cdx.B
 		func(path string) (err error) {
 			switch filepath.Ext(path) {
 			case ".pem", ".cer", ".cert", ".der", ".ca-bundle", ".crt":
+				_, err = os.Lstat(path)
+				if os.IsNotExist(err) {
+					log.WithError(err).Error("cert does not exist at path; continuing")
+					return nil
+				} else if err != nil {
+					return err
+				}
+
 				readCloser, err := fs.Open(path)
 				if err != nil {
 					return err
@@ -86,6 +94,14 @@ func (certificatesPlugin *Plugin) UpdateBOM(fs filesystem.Filesystem, bom *cdx.B
 				}
 				certificates = append(certificates, certs...)
 			case ".p7a", ".p7b", ".p7c", ".p7r", ".p7s", ".spc":
+				_, err = os.Lstat(path)
+				if os.IsNotExist(err) {
+					log.WithError(err).Error("cert does not exist at path; continuing")
+					return nil
+				} else if err != nil {
+					return err
+				}
+
 				readCloser, err := fs.Open(path)
 				if err != nil {
 					return err


### PR DESCRIPTION
If a file does not exist at the specified path, e.g. due to a broken symlink, there is no actual certificate referenced and hence it may just be skipped. Otherwise, an error would be raised which caused the whole CBOM generation to fail in case of broken symlinks.