### PR TITLE
Add `Exists` function to filesystem interface to fix broken existence check

### DIFF
--- a/provider/docker/layer.go
+++ b/provider/docker/layer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/IBM/cbomkit-theia/provider/filesystem"
 	scannererrors "github.com/IBM/cbomkit-theia/scanner/errors"
 	"io"
+	"strings"
 
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/filetree/filenode"
@@ -61,6 +62,18 @@ func (layer Layer) Open(path string) (io.ReadCloser, error) {
 		return nil, err
 	}
 	return readCloser, err
+}
+
+// Exists Check if a file at path exists in this layer
+func (layer Layer) Exists(path string) (bool, error) {
+	_, err := layer.OpenPathFromSquash(file.Path(path))
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "could not find file path in Tree") {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 // GetConfig Get the image config

--- a/scanner/plugins/certificates/certificates.go
+++ b/scanner/plugins/certificates/certificates.go
@@ -70,12 +70,12 @@ func (certificatesPlugin *Plugin) UpdateBOM(fs filesystem.Filesystem, bom *cdx.B
 		func(path string) (err error) {
 			switch filepath.Ext(path) {
 			case ".pem", ".cer", ".cert", ".der", ".ca-bundle", ".crt":
-				_, err = os.Lstat(path)
-				if os.IsNotExist(err) {
-					log.WithError(err).Error("cert does not exist at path; continuing")
-					return nil
-				} else if err != nil {
+				exists, err := fs.Exists(path)
+				if err != nil {
 					return err
+				} else if !exists {
+					log.WithField("path", path).Warning("Certificate does not exist")
+					return nil
 				}
 
 				readCloser, err := fs.Open(path)
@@ -92,12 +92,12 @@ func (certificatesPlugin *Plugin) UpdateBOM(fs filesystem.Filesystem, bom *cdx.B
 				}
 				certificates = append(certificates, certs...)
 			case ".p7a", ".p7b", ".p7c", ".p7r", ".p7s", ".spc":
-				_, err = os.Lstat(path)
-				if os.IsNotExist(err) {
-					log.WithError(err).Error("cert does not exist at path; continuing")
-					return nil
-				} else if err != nil {
+				exists, err := fs.Exists(path)
+				if err != nil {
 					return err
+				} else if !exists {
+					log.WithField("path", path).Warning("Certificate does not exist")
+					return nil
 				}
 
 				readCloser, err := fs.Open(path)


### PR DESCRIPTION
The previous check to detect if a file at `path` actually exists (or if it is for example a broken symlink) did not correctly work for relative paths, as those were relative to the `PlainFilesystem.rootPath`, whereas `os.Lstat` assumes the paths are relative to the working directory.