### PR TITLE
Refactor key, pem and x509 cycloneDX component generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/IBM/cbomkit-theia
 
-go 1.23.0
+go 1.24.1
+
 require (
 	github.com/CycloneDX/cyclonedx-go v0.9.2
 	github.com/anchore/stereoscope v0.1.0

--- a/scanner/errors/errors.go
+++ b/scanner/errors/errors.go
@@ -43,3 +43,9 @@ var ErrParsingFailedAlthoughChecked = errors.New("failed to parse file that was 
 func GetParsingFailedAlthoughCheckedError(parsingError error, plugin string) error {
 	return fmt.Errorf("%w: (%v) %w", ErrParsingFailedAlthoughChecked, plugin, parsingError)
 }
+
+// ErrUnknownKeyAlgorithm Error
+var ErrUnknownKeyAlgorithm = errors.New("key block uses unknown algorithm")
+
+// ErrX509UnknownAlgorithm During parsing of the x509.Certificate an unknown algorithm was found
+var ErrX509UnknownAlgorithm = errors.New("x.509 certificate has unknown algorithm")

--- a/scanner/key/key.go
+++ b/scanner/key/key.go
@@ -1,0 +1,165 @@
+package key
+
+import (
+	"crypto/dsa"
+	"crypto/ecdh"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/IBM/cbomkit-theia/scanner/errors"
+	"github.com/google/uuid"
+)
+
+func GenerateCdxComponents(keys []any) ([]cdx.Component, error) {
+	components := make([]cdx.Component, 0)
+	for _, key := range keys {
+		component, err := GenerateCdxComponent(key)
+		if err != nil {
+			return nil, err
+		}
+		components = append(components, *component)
+	}
+	return components, nil
+}
+
+func GenerateCdxComponent(key any) (*cdx.Component, error) {
+	switch key := key.(type) {
+	case *rsa.PublicKey:
+		return getRSAPublicKeyComponent(key), nil
+	case *dsa.PublicKey:
+		return getDSAPublicKeyComponent(key), nil
+	case *ecdsa.PublicKey:
+		return getECDSAPublicKeyComponent(key), nil
+	case *ed25519.PublicKey:
+		return getED25519PublicKeyComponent(key), nil
+	case *ecdh.PublicKey:
+		return getECDHPublicKeyComponent(key), nil
+	case *rsa.PrivateKey:
+		return getRSAPrivateKeyComponent(key), nil
+	case *ecdsa.PrivateKey:
+		return getECDSAPrivateKeyComponent(key), nil
+	case ed25519.PrivateKey:
+		return getED25519PrivateKeyComponent(), nil
+	case *ecdh.PrivateKey:
+		return getECDHPrivateKeyComponent(), nil
+	default:
+		return nil, errors.ErrUnknownKeyAlgorithm
+	}
+}
+
+func getGenericKeyComponent() *cdx.Component {
+	return &cdx.Component{
+		Type:   cdx.ComponentTypeCryptographicAsset,
+		BOMRef: uuid.New().String(),
+		CryptoProperties: &cdx.CryptoProperties{
+			AssetType: cdx.CryptoAssetTypeRelatedCryptoMaterial,
+			RelatedCryptoMaterialProperties: &cdx.RelatedCryptoMaterialProperties{
+				Type:   cdx.RelatedCryptoMaterialTypeKey,
+				Format: "PEM",
+			},
+		},
+	}
+}
+
+func getGenericPublicKeyComponent() *cdx.Component {
+	c := getGenericKeyComponent()
+	c.CryptoProperties.RelatedCryptoMaterialProperties.Type = cdx.RelatedCryptoMaterialTypePublicKey
+	return c
+}
+
+func getGenericPrivateKeyComponent() *cdx.Component {
+	c := getGenericKeyComponent()
+	c.CryptoProperties.RelatedCryptoMaterialProperties.Type = cdx.RelatedCryptoMaterialTypePrivateKey
+	return c
+}
+
+func getRSAPublicKeyComponent(key *rsa.PublicKey) *cdx.Component {
+	c := getGenericPublicKeyComponent()
+	size := key.Size() * 8 // byte
+	c.Name = fmt.Sprintf("RSA-%v", size)
+	c.CryptoProperties.RelatedCryptoMaterialProperties.Size = &size
+	c.CryptoProperties.OID = "1.2.840.113549.1.1.1"
+	keyValue, err := x509.MarshalPKIXPublicKey(key)
+	if err == nil {
+		c.CryptoProperties.RelatedCryptoMaterialProperties.Value = base64.StdEncoding.EncodeToString(keyValue)
+	}
+	return c
+}
+
+func getRSAPrivateKeyComponent(key *rsa.PrivateKey) *cdx.Component {
+	c := getGenericPrivateKeyComponent()
+	c.Name = "RSA"
+	size := key.PublicKey.Size() * 8 // byte
+	c.Name = fmt.Sprintf("RSA-%v", size)
+	c.CryptoProperties.RelatedCryptoMaterialProperties.Size = &size
+	c.CryptoProperties.OID = "1.2.840.113549.1.1.1"
+	return c
+}
+
+func getECDSAPublicKeyComponent(key *ecdsa.PublicKey) *cdx.Component {
+	c := getGenericPublicKeyComponent()
+	c.Name = "ECDSA"
+	c.CryptoProperties.OID = "1.2.840.10045.2.1"
+	keyValue, err := x509.MarshalPKIXPublicKey(key)
+	if err == nil {
+		c.CryptoProperties.RelatedCryptoMaterialProperties.Value = base64.StdEncoding.EncodeToString(keyValue)
+	}
+	return c
+}
+
+func getECDSAPrivateKeyComponent(key *ecdsa.PrivateKey) *cdx.Component {
+	c := getGenericPrivateKeyComponent()
+	c.Name = "ECDSA"
+	c.Description = fmt.Sprintf("Curve: %v", key.Curve.Params().Name)
+	return c
+}
+
+func getED25519PublicKeyComponent(key *ed25519.PublicKey) *cdx.Component {
+	c := getGenericPublicKeyComponent()
+	c.Name = "ED25519"
+	size := len([]byte(*key)) * 8
+	c.CryptoProperties.RelatedCryptoMaterialProperties.Size = &size
+	keyValue, err := x509.MarshalPKIXPublicKey(key)
+	if err == nil {
+		c.CryptoProperties.RelatedCryptoMaterialProperties.Value = base64.StdEncoding.EncodeToString(keyValue)
+	}
+	return c
+}
+
+func getED25519PrivateKeyComponent() *cdx.Component {
+	c := getGenericPrivateKeyComponent()
+	c.Name = "ED25519"
+	return c
+}
+
+func getECDHPublicKeyComponent(key *ecdh.PublicKey) *cdx.Component {
+	c := getGenericPublicKeyComponent()
+	c.Name = "ECDH"
+	size := len(key.Bytes()) * 8
+	c.CryptoProperties.RelatedCryptoMaterialProperties.Size = &size
+	c.CryptoProperties.OID = "1.2.840.10045.2.1"
+	keyValue, err := x509.MarshalPKIXPublicKey(key)
+	if err == nil {
+		c.CryptoProperties.RelatedCryptoMaterialProperties.Value = base64.StdEncoding.EncodeToString(keyValue)
+	}
+	return c
+}
+
+func getECDHPrivateKeyComponent() *cdx.Component {
+	c := getGenericPrivateKeyComponent()
+	c.Name = "ECDH"
+	return c
+}
+
+func getDSAPublicKeyComponent(key *dsa.PublicKey) *cdx.Component {
+	c := getGenericPublicKeyComponent()
+	c.Name = "DSA"
+	size := key.Y.BitLen()
+	c.CryptoProperties.RelatedCryptoMaterialProperties.Size = &size
+	c.CryptoProperties.OID = "1.3.14.3.2.12"
+	return c
+}

--- a/scanner/pem/pem.go
+++ b/scanner/pem/pem.go
@@ -17,51 +17,113 @@
 package pem
 
 import (
-	"crypto/dsa"
-	"crypto/ecdh"
-	"crypto/ecdsa"
-	"crypto/ed25519"
-	"crypto/rsa"
 	"crypto/x509"
-	"encoding/base64"
 	"encoding/pem"
-	"errors"
 	"fmt"
+	"github.com/IBM/cbomkit-theia/scanner/key"
 	"slices"
 
 	"golang.org/x/crypto/ssh"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
-	"github.com/google/uuid"
 )
 
 // Filter that describes which PEMBlockTypes to allow
 type Filter struct {
-	FilterType PEMTypeFilterType
-	List       []PEMBlockType
+	FilterType TypeFilterType
+	List       []BlockType
 }
 
-// PEMTypeFilterType Used to specify whether a filter is an allow- or blocklist
-type PEMTypeFilterType bool
+// TypeFilterType Used to specify whether a filter is an allow- or blocklist
+type TypeFilterType bool
 
 const (
-	PEMTypeFilterTypeAllowlist PEMTypeFilterType = true  // Allowlist
-	PEMTypeFilterTypeBlocklist PEMTypeFilterType = false // Blocklist
+	TypeAllowlist TypeFilterType = true  // Allowlist
+	TypeBlocklist TypeFilterType = false // Blocklist
 )
 
-// PEMBlockType A not complete list of PEMBlockTypes that can be detected currently
-type PEMBlockType string
+// BlockType A not complete list of PEMBlockTypes that can be detected currently
+type BlockType string
 
 const (
-	PEMBlockTypeCertificate         PEMBlockType = "CERTIFICATE"
-	PEMBlockTypePrivateKey          PEMBlockType = "PRIVATE KEY"
-	PEMBlockTypeEncryptedPrivateKey PEMBlockType = "ENCRYPTED PRIVATE KEY"
-	PEMBlockTypePublicKey           PEMBlockType = "PUBLIC KEY"
-	PEMBlockTypeECPrivateKey        PEMBlockType = "EC PRIVATE KEY"
-	PEMBlockTypeRSAPrivateKey       PEMBlockType = "RSA PRIVATE KEY"
-	PEMBlockTypeRSAPublicKey        PEMBlockType = "RSA PUBLIC KEY"
-	PEMBlockTypeOPENSSHPrivateKey   PEMBlockType = "OPENSSH PRIVATE KEY"
+	BlockTypeCertificate         BlockType = "CERTIFICATE"
+	BlockTypePrivateKey          BlockType = "PRIVATE KEY"
+	BlockTypeEncryptedPrivateKey BlockType = "ENCRYPTED PRIVATE KEY"
+	BlockTypePublicKey           BlockType = "PUBLIC KEY"
+	BlockTypeECPrivateKey        BlockType = "EC PRIVATE KEY"
+	BlockTypeRSAPrivateKey       BlockType = "RSA PRIVATE KEY"
+	BlockTypeRSAPublicKey        BlockType = "RSA PUBLIC KEY"
+	BlockTypeOPENSSHPrivateKey   BlockType = "OPENSSH PRIVATE KEY"
 )
+
+// ParsePEMToBlocksWithTypeFilter Just like ParsePEMToBlocksWithTypes but uses a filter for filtering
+func ParsePEMToBlocksWithTypeFilter(raw []byte, filter Filter) map[*pem.Block]BlockType {
+	blocksWithType := parsePEMToBlocksWithTypes(raw)
+	filteredBlocksWithType := make(map[*pem.Block]BlockType)
+
+	for block, t := range blocksWithType {
+		if slices.Contains(filter.List, t) == bool(filter.FilterType) {
+			filteredBlocksWithType[block] = t
+		}
+	}
+	return filteredBlocksWithType
+}
+
+// GenerateCdxComponents Generate cyclone-go components from a block containing a key
+func GenerateCdxComponents(block *pem.Block) ([]cdx.Component, error) {
+	switch BlockType(block.Type) {
+	case BlockTypePrivateKey:
+		rawKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return []cdx.Component{}, err
+		}
+		return key.GenerateCdxComponents([]any{rawKey})
+	case BlockTypeECPrivateKey:
+		rawKey, err := x509.ParseECPrivateKey(block.Bytes)
+		if err != nil {
+			return []cdx.Component{}, err
+		}
+		return key.GenerateCdxComponents([]any{rawKey, &rawKey.PublicKey})
+	case BlockTypeRSAPrivateKey:
+		rawKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			return []cdx.Component{}, err
+		}
+		return key.GenerateCdxComponents([]any{rawKey, &rawKey.PublicKey})
+	case BlockTypePublicKey:
+		rawKey, err := x509.ParsePKIXPublicKey(block.Bytes)
+		if err != nil {
+			return []cdx.Component{}, err
+		}
+		return key.GenerateCdxComponents([]any{rawKey})
+	case BlockTypeRSAPublicKey:
+		rawKey, err := x509.ParsePKCS1PublicKey(block.Bytes)
+		if err != nil {
+			return []cdx.Component{}, err
+		}
+		return key.GenerateCdxComponents([]any{rawKey})
+	case BlockTypeOPENSSHPrivateKey:
+		rawKey, err := ssh.ParseRawPrivateKey(pem.EncodeToMemory(block))
+		if err != nil {
+			return []cdx.Component{}, err
+		}
+		return key.GenerateCdxComponents([]any{rawKey})
+	default:
+		return []cdx.Component{}, fmt.Errorf("could not generate component from PEM. Block type is unknown or not a key")
+	}
+}
+
+// Parse the []byte of a PEM file to a map containing the *pem.Block and a PEMBlockType for each block
+func parsePEMToBlocksWithTypes(raw []byte) map[*pem.Block]BlockType {
+	blocks := parsePEMToBlocks(raw)
+
+	blocksWithType := make(map[*pem.Block]BlockType, len(blocks))
+
+	for _, block := range blocks {
+		blocksWithType[block] = BlockType(block.Type)
+	}
+	return blocksWithType
+}
 
 func parsePEMToBlocks(raw []byte) []*pem.Block {
 	rest := raw
@@ -76,223 +138,4 @@ func parsePEMToBlocks(raw []byte) []*pem.Block {
 		}
 	}
 	return blocks
-}
-
-// ParsePEMToBlocksWithTypes Parse the []byte of a PEM file to a map
-// containing the *pem.Block and a PEMBlockType for each block
-func ParsePEMToBlocksWithTypes(raw []byte) map[*pem.Block]PEMBlockType {
-	blocks := parsePEMToBlocks(raw)
-
-	blocksWithType := make(map[*pem.Block]PEMBlockType, len(blocks))
-
-	for _, block := range blocks {
-		blocksWithType[block] = PEMBlockType(block.Type)
-	}
-
-	return blocksWithType
-}
-
-// ParsePEMToBlocksWithTypeFilter Just like ParsePEMToBlocksWithTypes but uses a filter for filtering
-func ParsePEMToBlocksWithTypeFilter(raw []byte, filter Filter) map[*pem.Block]PEMBlockType {
-	blocksWithType := ParsePEMToBlocksWithTypes(raw)
-	filteredBlocksWithType := make(map[*pem.Block]PEMBlockType)
-
-	for block, t := range blocksWithType {
-		if slices.Contains(filter.List, t) == bool(filter.FilterType) {
-			filteredBlocksWithType[block] = t
-		}
-	}
-
-	return filteredBlocksWithType
-}
-
-var errUnknownKeyAlgorithm = errors.New("key block uses unknown algorithm")
-
-// GenerateComponentsFromPEMKeyBlock Generate cyclone-go components from a block containing a key
-func GenerateComponentsFromPEMKeyBlock(block *pem.Block) ([]cdx.Component, error) {
-	switch PEMBlockType(block.Type) {
-
-	case PEMBlockTypePrivateKey:
-		genericKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-		if err != nil {
-			return []cdx.Component{}, err
-		}
-		return GenerateComponentsFromKey(genericKey)
-
-	case PEMBlockTypeECPrivateKey:
-		key, err := x509.ParseECPrivateKey(block.Bytes)
-		if err != nil {
-			return []cdx.Component{}, err
-		}
-		return []cdx.Component{getECDSAPrivateKeyComponent(key), getECDSAPublicKeyComponent(&key.PublicKey)}, nil
-
-	case PEMBlockTypeRSAPrivateKey:
-		key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
-		if err != nil {
-			return []cdx.Component{}, err
-		}
-		return []cdx.Component{getRSAPrivateKeyComponent(key), getRSAPublicKeyComponent(&key.PublicKey)}, nil
-
-	case PEMBlockTypePublicKey:
-		genericKey, err := x509.ParsePKIXPublicKey(block.Bytes)
-		if err != nil {
-			return []cdx.Component{}, err
-		}
-		return GenerateComponentsFromKey(genericKey)
-
-	case PEMBlockTypeRSAPublicKey:
-		key, err := x509.ParsePKCS1PublicKey(block.Bytes)
-		if err != nil {
-			return []cdx.Component{}, err
-		}
-		return []cdx.Component{getRSAPublicKeyComponent(key)}, nil
-
-	case PEMBlockTypeOPENSSHPrivateKey:
-		genericKey, err := ssh.ParseRawPrivateKey(pem.EncodeToMemory(block))
-		if err != nil {
-			return []cdx.Component{}, err
-		}
-		return GenerateComponentsFromKey(genericKey)
-
-	default:
-		return []cdx.Component{}, fmt.Errorf("could not generate cyclone-dx component from pem: pem file block type is unknown or not a key")
-	}
-}
-
-func GenerateComponentsFromKey(genericKey any) ([]cdx.Component, error) {
-	switch key := genericKey.(type) {
-	case *rsa.PublicKey:
-		return []cdx.Component{getRSAPublicKeyComponent(key)}, nil
-	case *dsa.PublicKey:
-		return []cdx.Component{getDSAPublicKeyComponent(key)}, nil
-	case *ecdsa.PublicKey:
-		return []cdx.Component{getECDSAPublicKeyComponent(key)}, nil
-	case *ed25519.PublicKey:
-		return []cdx.Component{getED25519PublicKeyComponent(key)}, nil
-	case *ecdh.PublicKey:
-		return []cdx.Component{getECDHPublicKeyComponent(key)}, nil
-	case *rsa.PrivateKey:
-		return []cdx.Component{getRSAPrivateKeyComponent(key)}, nil
-	case *ecdsa.PrivateKey:
-		return []cdx.Component{getECDSAPrivateKeyComponent(key)}, nil
-	case ed25519.PrivateKey:
-		return []cdx.Component{getED25519PrivateKeyComponent()}, nil
-	case *ecdh.PrivateKey:
-		return []cdx.Component{getECDHPrivateKeyComponent()}, nil
-	default:
-		return []cdx.Component{}, errUnknownKeyAlgorithm
-	}
-}
-
-func getGenericKeyComponent() cdx.Component {
-	return cdx.Component{
-		Type:   cdx.ComponentTypeCryptographicAsset,
-		BOMRef: uuid.New().String(),
-		CryptoProperties: &cdx.CryptoProperties{
-			AssetType: cdx.CryptoAssetTypeRelatedCryptoMaterial,
-			RelatedCryptoMaterialProperties: &cdx.RelatedCryptoMaterialProperties{
-				Type:   cdx.RelatedCryptoMaterialTypeKey,
-				Format: "PEM",
-			},
-		},
-	}
-}
-
-func getGenericPublicKeyComponent() cdx.Component {
-	c := getGenericKeyComponent()
-	c.CryptoProperties.RelatedCryptoMaterialProperties.Type = cdx.RelatedCryptoMaterialTypePublicKey
-	return c
-}
-
-func getGenericPrivateKeyComponent() cdx.Component {
-	c := getGenericKeyComponent()
-	c.CryptoProperties.RelatedCryptoMaterialProperties.Type = cdx.RelatedCryptoMaterialTypePrivateKey
-	return c
-}
-
-func getRSAPublicKeyComponent(key *rsa.PublicKey) cdx.Component {
-	c := getGenericPublicKeyComponent()
-	size := key.Size() * 8 // byte
-	c.Name = fmt.Sprintf("RSA-%v", size)
-	c.CryptoProperties.RelatedCryptoMaterialProperties.Size = &size
-	c.CryptoProperties.OID = "1.2.840.113549.1.1.1"
-	keyValue, err := x509.MarshalPKIXPublicKey(key)
-	if err == nil {
-		c.CryptoProperties.RelatedCryptoMaterialProperties.Value = base64.StdEncoding.EncodeToString(keyValue)
-	}
-	return c
-}
-
-func getRSAPrivateKeyComponent(key *rsa.PrivateKey) cdx.Component {
-	c := getGenericPrivateKeyComponent()
-	c.Name = "RSA"
-	size := key.PublicKey.Size() * 8 // byte
-	c.Name = fmt.Sprintf("RSA-%v", size)
-	c.CryptoProperties.RelatedCryptoMaterialProperties.Size = &size
-	c.CryptoProperties.OID = "1.2.840.113549.1.1.1"
-	return c
-}
-
-func getECDSAPublicKeyComponent(key *ecdsa.PublicKey) cdx.Component {
-	c := getGenericPublicKeyComponent()
-	c.Name = "ECDSA"
-	c.CryptoProperties.OID = "1.2.840.10045.2.1"
-	keyValue, err := x509.MarshalPKIXPublicKey(key)
-	if err == nil {
-		c.CryptoProperties.RelatedCryptoMaterialProperties.Value = base64.StdEncoding.EncodeToString(keyValue)
-	}
-	return c
-}
-
-func getECDSAPrivateKeyComponent(key *ecdsa.PrivateKey) cdx.Component {
-	c := getGenericPrivateKeyComponent()
-	c.Name = "ECDSA"
-	c.Description = fmt.Sprintf("Curve: %v", key.Curve.Params().Name)
-	return c
-}
-
-func getED25519PublicKeyComponent(key *ed25519.PublicKey) cdx.Component {
-	c := getGenericPublicKeyComponent()
-	c.Name = "ED25519"
-	size := len([]byte(*key)) * 8
-	c.CryptoProperties.RelatedCryptoMaterialProperties.Size = &size
-	keyValue, err := x509.MarshalPKIXPublicKey(key)
-	if err == nil {
-		c.CryptoProperties.RelatedCryptoMaterialProperties.Value = base64.StdEncoding.EncodeToString(keyValue)
-	}
-	return c
-}
-
-func getED25519PrivateKeyComponent() cdx.Component {
-	c := getGenericPrivateKeyComponent()
-	c.Name = "ED25519"
-	return c
-}
-
-func getECDHPublicKeyComponent(key *ecdh.PublicKey) cdx.Component {
-	c := getGenericPublicKeyComponent()
-	c.Name = "ECDH"
-	size := len(key.Bytes()) * 8
-	c.CryptoProperties.RelatedCryptoMaterialProperties.Size = &size
-	c.CryptoProperties.OID = "1.2.840.10045.2.1"
-	keyValue, err := x509.MarshalPKIXPublicKey(key)
-	if err == nil {
-		c.CryptoProperties.RelatedCryptoMaterialProperties.Value = base64.StdEncoding.EncodeToString(keyValue)
-	}
-	return c
-}
-
-func getECDHPrivateKeyComponent() cdx.Component {
-	c := getGenericPrivateKeyComponent()
-	c.Name = "ECDH"
-	return c
-}
-
-func getDSAPublicKeyComponent(key *dsa.PublicKey) cdx.Component {
-	c := getGenericPublicKeyComponent()
-	c.Name = "DSA"
-	size := key.Y.BitLen()
-	c.CryptoProperties.RelatedCryptoMaterialProperties.Size = &size
-	c.CryptoProperties.OID = "1.3.14.3.2.12"
-	return c
 }

--- a/scanner/plugins/certificates/certificate_test.go
+++ b/scanner/plugins/certificates/certificate_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/IBM/cbomkit-theia/provider/cyclonedx"
+	x509lib "github.com/IBM/cbomkit-theia/scanner/x509"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
@@ -54,14 +55,14 @@ func TestIssue56(t *testing.T) {
 		assert.Equal(t, EcdsaSha384Cert.SignatureAlgorithm, x509.ECDSAWithSHA384)
 
 		bom := cdx.NewBOM()
-		components, dependencyMap, err := EcdsaSha256Cert.GetCDXComponents()
+		components, dependencyMap, err := x509lib.GenerateCdxComponents(EcdsaSha256Cert)
 		if err != nil {
 			t.Fail()
 		}
 		cyclonedx.AddComponents(bom, *components)
 		cyclonedx.AddDependencies(bom, *dependencyMap)
 
-		components, dependencyMap, err = EcdsaSha384Cert.GetCDXComponents()
+		components, dependencyMap, err = x509lib.GenerateCdxComponents(EcdsaSha384Cert)
 		if err != nil {
 			t.Fail()
 		}

--- a/scanner/plugins/certificates/certificates.go
+++ b/scanner/plugins/certificates/certificates.go
@@ -19,6 +19,7 @@ package certificates
 import (
 	"encoding/pem"
 	"github.com/IBM/cbomkit-theia/provider/cyclonedx"
+	"github.com/IBM/cbomkit-theia/scanner/x509"
 	log "github.com/sirupsen/logrus"
 	"os"
 	"path/filepath"
@@ -26,7 +27,7 @@ import (
 
 	"github.com/IBM/cbomkit-theia/provider/filesystem"
 	scannererrors "github.com/IBM/cbomkit-theia/scanner/errors"
-	pemutility "github.com/IBM/cbomkit-theia/scanner/pem"
+	pemlib "github.com/IBM/cbomkit-theia/scanner/pem"
 	"github.com/IBM/cbomkit-theia/scanner/plugins"
 
 	"go.mozilla.org/pkcs7"
@@ -58,7 +59,7 @@ func NewCertificatePlugin() (plugins.Plugin, error) {
 
 // UpdateBOM Add the found certificates to the slice of components
 func (certificatesPlugin *Plugin) UpdateBOM(fs filesystem.Filesystem, bom *cdx.BOM) error {
-	var certificates []*x509CertificateWithMetadata
+	var certificates []*x509.CertificateWithMetadata
 
 	// Set GODEBUG to allow negative serial numbers (see https://github.com/golang/go/commit/db13584baedce4909915cb4631555f6dbd7b8c38)
 	err := setX509NegativeSerial()
@@ -132,7 +133,7 @@ func (certificatesPlugin *Plugin) UpdateBOM(fs filesystem.Filesystem, bom *cdx.B
 	log.WithField("numberOfDetectedCertificates", len(certificates)).Info("Certificate searching done")
 
 	for _, cert := range certificates {
-		components, dependencyMap, err := cert.GetCDXComponents()
+		components, dependencyMap, err := x509.GenerateCdxComponents(cert)
 		if err != nil {
 			log.WithError(err).Error("Error while adding certificate data to bom")
 			continue
@@ -144,20 +145,20 @@ func (certificatesPlugin *Plugin) UpdateBOM(fs filesystem.Filesystem, bom *cdx.B
 }
 
 // Parse an X.509 certificate from the given path (in base64 PEM or binary DER)
-func parseX509CertFromPath(raw []byte, path string) ([]*x509CertificateWithMetadata, error) {
-	blocks := pemutility.ParsePEMToBlocksWithTypeFilter(raw, pemutility.Filter{
-		FilterType: pemutility.PEMTypeFilterTypeAllowlist,
-		List:       []pemutility.PEMBlockType{pemutility.PEMBlockTypeCertificate},
+func parseX509CertFromPath(raw []byte, path string) ([]*x509.CertificateWithMetadata, error) {
+	blocks := pemlib.ParsePEMToBlocksWithTypeFilter(raw, pemlib.Filter{
+		FilterType: pemlib.TypeAllowlist,
+		List:       []pemlib.BlockType{pemlib.BlockTypeCertificate},
 	})
 
 	if len(blocks) == 0 {
-		return parseCertificatesToX509CertificateWithMetadata(raw, path)
+		return x509.ParseCertificatesToX509CertificateWithMetadata(raw, path)
 	}
 
-	certs := make([]*x509CertificateWithMetadata, 0, len(blocks))
+	certs := make([]*x509.CertificateWithMetadata, 0, len(blocks))
 
 	for block := range blocks {
-		moreCerts, err := parseCertificatesToX509CertificateWithMetadata(block.Bytes, path)
+		moreCerts, err := x509.ParseCertificatesToX509CertificateWithMetadata(block.Bytes, path)
 		if err != nil {
 			return moreCerts, err
 		}
@@ -168,20 +169,20 @@ func parseX509CertFromPath(raw []byte, path string) ([]*x509CertificateWithMetad
 }
 
 // Parse X.509 certificates from a PKCS7 file (base64 PEM format)
-func parsePKCS7FromPath(raw []byte, path string) ([]*x509CertificateWithMetadata, error) {
+func parsePKCS7FromPath(raw []byte, path string) ([]*x509.CertificateWithMetadata, error) {
 	block, _ := pem.Decode(raw)
 
 	pkcs7Object, err := pkcs7.Parse(block.Bytes)
 	if err != nil || pkcs7Object == nil {
-		return make([]*x509CertificateWithMetadata, 0), err
+		return make([]*x509.CertificateWithMetadata, 0), err
 	}
 
-	certsWithMetadata := make([]*x509CertificateWithMetadata, 0, len(pkcs7Object.Certificates))
+	certsWithMetadata := make([]*x509.CertificateWithMetadata, 0, len(pkcs7Object.Certificates))
 
 	for _, cert := range pkcs7Object.Certificates {
-		certWithMetadata, err := newX509CertificateWithMetadata(cert, path)
+		certWithMetadata, err := x509.NewX509CertificateWithMetadata(cert, path)
 		if err != nil {
-			return make([]*x509CertificateWithMetadata, 0), err
+			return make([]*x509.CertificateWithMetadata, 0), err
 		}
 		certsWithMetadata = append(certsWithMetadata, certWithMetadata)
 	}

--- a/scanner/plugins/secrets/secrets.go
+++ b/scanner/plugins/secrets/secrets.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/IBM/cbomkit-theia/provider/filesystem"
-	pemlib "github.com/IBM/cbomkit-theia/scanner/pem"
+	"github.com/IBM/cbomkit-theia/scanner/pem"
 	"github.com/IBM/cbomkit-theia/scanner/plugins"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
@@ -141,19 +141,19 @@ func (finding findingWithMetadata) getComponents() ([]cdx.Component, error) {
 
 func (finding findingWithMetadata) getPrivateKeyComponent() ([]cdx.Component, error) {
 	// Filter for private keys only
-	privateKeyFilter := pemlib.Filter{
-		FilterType: pemlib.PEMTypeFilterTypeAllowlist,
-		List: []pemlib.PEMBlockType{
-			pemlib.PEMBlockTypePrivateKey,
-			pemlib.PEMBlockTypeEncryptedPrivateKey,
-			pemlib.PEMBlockTypeRSAPrivateKey,
-			pemlib.PEMBlockTypeECPrivateKey,
-			pemlib.PEMBlockTypeOPENSSHPrivateKey,
+	privateKeyFilter := pem.Filter{
+		FilterType: pem.TypeAllowlist,
+		List: []pem.BlockType{
+			pem.BlockTypePrivateKey,
+			pem.BlockTypeEncryptedPrivateKey,
+			pem.BlockTypeRSAPrivateKey,
+			pem.BlockTypeECPrivateKey,
+			pem.BlockTypeOPENSSHPrivateKey,
 		},
 	}
 
 	// Parse PEM blocks
-	blocks := pemlib.ParsePEMToBlocksWithTypeFilter(finding.raw, privateKeyFilter)
+	blocks := pem.ParsePEMToBlocksWithTypeFilter(finding.raw, privateKeyFilter)
 	if len(blocks) == 0 {
 		return []cdx.Component{finding.getGenericSecretComponent()}, nil
 	}
@@ -162,7 +162,7 @@ func (finding findingWithMetadata) getPrivateKeyComponent() ([]cdx.Component, er
 
 	components := make([]cdx.Component, 0)
 	for block := range blocks {
-		currentComponents, err := pemlib.GenerateComponentsFromPEMKeyBlock(block)
+		currentComponents, err := pem.GenerateCdxComponents(block)
 		if err != nil {
 			continue
 		}

--- a/scanner/x509/x509.go
+++ b/scanner/x509/x509.go
@@ -14,55 +14,51 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package certificates
+package x509
 
 import (
 	"crypto/x509"
-	"errors"
 	"fmt"
+	"github.com/IBM/cbomkit-theia/scanner/errors"
+	"github.com/IBM/cbomkit-theia/scanner/key"
 	"path/filepath"
 	"time"
-
-	pemutility "github.com/IBM/cbomkit-theia/scanner/pem"
 
 	"github.com/google/uuid"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
 )
 
-// An X.509 certificate with additional metadata that is not part of the x509.Certificate struct
-type x509CertificateWithMetadata struct {
+// CertificateWithMetadata An X.509 certificate with additional metadata that is not part of the x509.Certificate struct
+type CertificateWithMetadata struct {
 	*x509.Certificate
 	path   string
 	format string
 }
 
-// During parsing of the x509.Certificate an unknown algorithm was found
-var errX509UnknownAlgorithm = errors.New("x.509 certificate has unknown algorithm")
-
-// Create a new x509CertificateWithMetadata from a x509.Certificate and a path
-func newX509CertificateWithMetadata(cert *x509.Certificate, path string) (*x509CertificateWithMetadata, error) {
+// NewX509CertificateWithMetadata Create a new x509CertificateWithMetadata from a x509.Certificate and a path
+func NewX509CertificateWithMetadata(cert *x509.Certificate, path string) (*CertificateWithMetadata, error) {
 	if cert == nil {
 		return nil, fmt.Errorf("certificate is nil")
 	}
-	return &x509CertificateWithMetadata{
+	return &CertificateWithMetadata{
 		cert,
 		path,
 		"X.509",
 	}, nil
 }
 
-// Convenience function to parse der bytes into a slice of x509CertificateWithMetadata
-func parseCertificatesToX509CertificateWithMetadata(der []byte, path string) ([]*x509CertificateWithMetadata, error) {
+// ParseCertificatesToX509CertificateWithMetadata Convenience function to parse der bytes into a slice of x509CertificateWithMetadata
+func ParseCertificatesToX509CertificateWithMetadata(der []byte, path string) ([]*CertificateWithMetadata, error) {
 	certs, err := x509.ParseCertificates(der)
 	if err != nil {
-		return make([]*x509CertificateWithMetadata, 0), err
+		return make([]*CertificateWithMetadata, 0), err
 	}
 
-	certsWithMetadata := make([]*x509CertificateWithMetadata, 0, len(certs))
+	certsWithMetadata := make([]*CertificateWithMetadata, 0, len(certs))
 
 	for _, cert := range certs {
-		certWithMetadata, err := newX509CertificateWithMetadata(cert, path)
+		certWithMetadata, err := NewX509CertificateWithMetadata(cert, path)
 		if err != nil {
 			return certsWithMetadata, err
 		}
@@ -72,14 +68,14 @@ func parseCertificatesToX509CertificateWithMetadata(der []byte, path string) ([]
 	return certsWithMetadata, err
 }
 
-func (x509CertificateWithMetadata *x509CertificateWithMetadata) GetCDXComponents() (*[]cdx.Component, *map[cdx.BOMReference][]string, error) {
+func GenerateCdxComponents(certificateWithMetadata *CertificateWithMetadata) (*[]cdx.Component, *map[cdx.BOMReference][]string, error) {
 	// Creating BOM Components
 	components := make([]cdx.Component, 0)
 	dependencyMap := make(map[cdx.BOMReference][]string)
 	// get certificate algorithm as cdx component
-	certificate := x509CertificateWithMetadata.getCertificateComponent()
+	certificate := certificateWithMetadata.getCertificateComponent()
 	// get signature algorithm as cdx component
-	signatureAlgorithm, err := x509CertificateWithMetadata.getSignatureAlgorithmComponent()
+	signatureAlgorithm, err := certificateWithMetadata.getSignatureAlgorithmComponent()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -96,13 +92,13 @@ func (x509CertificateWithMetadata *x509CertificateWithMetadata) GetCDXComponents
 		components = append(components, *signatureAlgorithm.signature)
 	}
 	// add public key algorithm
-	publicKeyAlgorithm, err := x509CertificateWithMetadata.getPublicKeyAlgorithmComponent()
+	publicKeyAlgorithm, err := certificateWithMetadata.getPublicKeyAlgorithmComponent()
 	if err != nil {
 		return nil, nil, err
 	}
 	components = append(components, publicKeyAlgorithm)
 	// add public key
-	publicKey, err := x509CertificateWithMetadata.getPublicKeyComponent()
+	publicKey, err := certificateWithMetadata.getPublicKeyComponent()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -117,7 +113,7 @@ func (x509CertificateWithMetadata *x509CertificateWithMetadata) GetCDXComponents
 }
 
 // Generate the CycloneDX component for the certificate
-func (x509CertificateWithMetadata *x509CertificateWithMetadata) getCertificateComponent() cdx.Component {
+func (x509CertificateWithMetadata *CertificateWithMetadata) getCertificateComponent() cdx.Component {
 	return cdx.Component{
 		Type:   cdx.ComponentTypeCryptographicAsset,
 		Name:   x509CertificateWithMetadata.Subject.CommonName,
@@ -149,7 +145,7 @@ type signatureAlgorithmResult struct {
 }
 
 // Generate the CycloneDX component for the signature algorithm
-func (x509CertificateWithMetadata *x509CertificateWithMetadata) getSignatureAlgorithmComponent() (signatureAlgorithmResult, error) {
+func (x509CertificateWithMetadata *CertificateWithMetadata) getSignatureAlgorithmComponent() (signatureAlgorithmResult, error) {
 	switch x509CertificateWithMetadata.SignatureAlgorithm {
 	case x509.MD2WithRSA:
 		comp := getGenericSignatureAlgorithmComponent(x509CertificateWithMetadata.SignatureAlgorithm, x509CertificateWithMetadata.path)
@@ -420,7 +416,7 @@ func (x509CertificateWithMetadata *x509CertificateWithMetadata) getSignatureAlgo
 			signature: nil,
 			hash:      nil,
 			pke:       nil,
-		}, errX509UnknownAlgorithm
+		}, errors.ErrX509UnknownAlgorithm
 	}
 }
 
@@ -489,28 +485,22 @@ func getGenericPKEAlgorithmComponent(path string) cdx.Component {
 }
 
 // Generate the CycloneDX component for the public key
-func (x509CertificateWithMetadata *x509CertificateWithMetadata) getPublicKeyComponent() (cdx.Component, error) {
-	comps, err := pemutility.GenerateComponentsFromKey(x509CertificateWithMetadata.PublicKey)
+func (x509CertificateWithMetadata *CertificateWithMetadata) getPublicKeyComponent() (cdx.Component, error) {
+	component, err := key.GenerateCdxComponent(x509CertificateWithMetadata.PublicKey)
 	if err != nil {
 		return cdx.Component{}, err
 	}
 
-	if len(comps) > 1 {
-		return cdx.Component{}, fmt.Errorf("certificate plugin: parsed several components from a single key. this should not happen. Check if getPublicKeyComponent gets only public keys")
-	}
-
-	comp := comps[0]
-	comp.Evidence = &cdx.Evidence{
+	component.Evidence = &cdx.Evidence{
 		Occurrences: &[]cdx.EvidenceOccurrence{
 			{Location: x509CertificateWithMetadata.path},
 		},
 	}
-
-	return comp, nil
+	return *component, nil
 }
 
 // Generate the CycloneDX component for the public key algorithm
-func (x509CertificateWithMetadata *x509CertificateWithMetadata) getPublicKeyAlgorithmComponent() (cdx.Component, error) {
+func (x509CertificateWithMetadata *CertificateWithMetadata) getPublicKeyAlgorithmComponent() (cdx.Component, error) {
 	switch x509CertificateWithMetadata.PublicKeyAlgorithm {
 	case x509.RSA:
 		comp := getGenericPublicKeyAlgorithmComponent(x509CertificateWithMetadata.PublicKeyAlgorithm, x509CertificateWithMetadata.path)
@@ -530,7 +520,7 @@ func (x509CertificateWithMetadata *x509CertificateWithMetadata) getPublicKeyAlgo
 		comp.CryptoProperties.OID = "1.3.101.112"
 		return comp, nil
 	default:
-		return getGenericPublicKeyAlgorithmComponent(x509CertificateWithMetadata.PublicKeyAlgorithm, x509CertificateWithMetadata.path), errX509UnknownAlgorithm
+		return getGenericPublicKeyAlgorithmComponent(x509CertificateWithMetadata.PublicKeyAlgorithm, x509CertificateWithMetadata.path), errors.ErrX509UnknownAlgorithm
 	}
 }
 


### PR DESCRIPTION
This pr
- moves the conversion of `keys` to cycloneDX components to a separate package
- updates `pem` package to use the new `key` package and some refactoring
- moves `x509` parsing and conversion to cycloneDX components to a separate package 